### PR TITLE
AFTER_SCRIPT option for htmlproofer 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,14 @@ jobs:
   fast_finish: true
   include:
     - name: "[Foxy] - htmlproofer"
-      env: SCRIPT=htmlproofer.sh
+      env: AFTER_SCRIPT=htmlproofer.sh
     - name: "[Foxy] - clang-format, ament_lint"
       env: TEST="clang-format ament_lint"
     - name: "[Foxy] - gcc (build,test)"
       env: ROS_DISTRO=foxy
 
 before_script:
-  - git clone -q -b ros2 --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
+  - git clone -q -b pr-after_script --depth=1 https://github.com/MarqRazz/moveit_ci.git .moveit_ci
 
 script:
   - .moveit_ci/travis.sh

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -5,19 +5,10 @@ set -e
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 export REPOSITORY_NAME=${PWD##*/}
 echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-sudo -E sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
-wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-sudo apt-get update -qq
-sudo apt-get install -qq -y python-rosdep
-# Setup rosdep
-sudo rosdep init
-rosdep update
 # Install htmlpoofer
 gem update --system
 gem --version
 gem install html-proofer
-
-source /opt/ros/foxy/setup.bash
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
 sphinx-build -W -b html . native_build

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -1,8 +1,8 @@
 repositories:
-  moveit2_tutorials:
-    type: git
-    url: https://github.com/ros-planning/moveit2_tutorials.git
-    version: main
+#  moveit2_tutorials:
+#    type: git
+#    url: https://github.com/ros-planning/moveit2_tutorials.git
+#    version: main
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
also switched moveit_ci to proto branch

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
