### PR TITLE
Update moveit_task_constructor_tutorial.rst

### DIFF
--- a/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
+++ b/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
@@ -75,7 +75,7 @@ There are three possible stages relating to the result flow: generator, propagat
 **Generators** compute their results independently of their neighbor stages and pass them in both directions, backwards and forwards.
 An example is an IK sampler for geometric poses where approaching and departing motions (neighbor stages) depend on the solution.
 
-**Propagators** receive the result of one neighbor stage, solve a subproblem and then propagate their result to the neighbor on the opposite site.
+**Propagators** receive the result of one neighbor stage, solve a subproblem and then propagate their result to the neighbor on the opposite side.
 Depending on the implementation, propagating stages can pass solutions forward, backward or in both directions separately.
 An example is a stage that computes a Cartesian path based on either a start or a goal state.
 


### PR DESCRIPTION
corrected typo: "site" to "side"

### Description
There was a typo in the file moveit_task_constructor_tutorial.rst. The correct term should be "opposite side" instead of "opposite site".

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
